### PR TITLE
sample support for panorama in panos provider

### DIFF
--- a/panos/provider.go
+++ b/panos/provider.go
@@ -117,7 +117,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		}
 	}
 
-	fw := &pango.Firewall{Client: pango.Client{
+	con, err := pango.Connect(pango.Client{
 		Hostname: d.Get("hostname").(string),
 		Username: d.Get("username").(string),
 		Password: d.Get("password").(string),
@@ -126,10 +126,10 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		Port:     uint(d.Get("port").(int)),
 		Timeout:  d.Get("timeout").(int),
 		Logging:  logging,
-	}}
-	if err := fw.Initialize(); err != nil {
+	})
+	if err != nil {
 		return nil, err
 	}
 
-	return fw, nil
+	return con, nil
 }

--- a/website/docs/r/address_object.html.markdown
+++ b/website/docs/r/address_object.html.markdown
@@ -10,11 +10,26 @@ description: |-
 
 This resource allows you to add/update/delete address objects.
 
+## PAN-OS Support
+
+* Firewall
+* Panorama
+
 ## Example Usage
 
 ```hcl
+# Firewall example.
 resource "panos_address_object" "example" {
     name = "localnet"
+    value = "192.168.80.0/24"
+    description = "The 192.168.80 network"
+    tags = ["internal", "dmz"]
+}
+
+# Panorama example.
+resource "panos_address_object" "example" {
+    name = "localnet"
+    device_group = "My Group"
     value = "192.168.80.0/24"
     description = "The 192.168.80 network"
     tags = ["internal", "dmz"]
@@ -26,8 +41,10 @@ resource "panos_address_object" "example" {
 The following arguments are supported:
 
 * `name` - (Required) The address object's name.
-* `vsys` - (Optional) The vsys to put the address object into (default:
-  `vsys1`).
+* `vsys` - (Optional) The firewall vsys to put the address object into
+  (default: `vsys1`).
+* `device_group` - (Optional) The Panorama device group to put the address
+  object into (default: `shared`)
 * `type` - (Optional) The type of address object.  This can be `ip-netmask`
   (default), `ip-range`, or `fqdn`.
 * `value` - (Required) The address object's value.  This can take various


### PR DESCRIPTION
This adds support for the Panorama appliance in the `panos` provider package.  Instead of making a `*pango.Firewall` in the provider function, we use `pango.Connect()`, which will return either a `*pango.Firewall` or `*pango.Panorama`.

Adding support for Panorama in the existing panos package was done because customers know that PAN-OS is running on both the firewalls and Panorama (the management device), and I believe the expectation on their part will be that the one provider works on both products.  There are some resources, such as this one, where the differences between the implementations is slight, so this is a good starting resource as there aren't many changes.

I'm mostly requesting feedback on code layout.  Is how I'm implementing this ok?  Is there something more idiomatic that I should be doing?  Having second thoughts about having support for both in the same provider after seeing it?  Etc.