### PR TITLE
panos/test-infra: Ensure EC2 Instance delete on termination for root EBS volume is enabled

### DIFF
--- a/panos/test-infra/aws-panorama/main.tf
+++ b/panos/test-infra/aws-panorama/main.tf
@@ -108,13 +108,16 @@ data "aws_ami" "panorama" {
 }
 
 resource "aws_instance" "main" {
-  ami = "${data.aws_ami.panorama.id}"
-
+  ami                         = "${data.aws_ami.panorama.id}"
+  associate_public_ip_address = true
   instance_type               = "m4.2xlarge"
+  key_name                    = "${aws_key_pair.default.key_name}"
   subnet_id                   = "${aws_subnet.default.id}"
   vpc_security_group_ids      = ["${aws_security_group.main.id}"]
-  key_name                    = "${aws_key_pair.default.key_name}"
-  associate_public_ip_address = true
+
+  root_block_device {
+    delete_on_termination = true
+  }
 
   tags = {
     Name = "tf-acc-panorama-${random_id.name.hex}"

--- a/panos/test-infra/aws-panos/main.tf
+++ b/panos/test-infra/aws-panos/main.tf
@@ -108,13 +108,16 @@ data "aws_ami" "panos" {
 }
 
 resource "aws_instance" "main" {
-  ami = "${data.aws_ami.panos.id}"
-
+  ami                         = "${data.aws_ami.panos.id}"
+  associate_public_ip_address = true
   instance_type               = "m5.xlarge"
+  key_name                    = "${aws_key_pair.default.key_name}"
   subnet_id                   = "${aws_subnet.default.id}"
   vpc_security_group_ids      = ["${aws_security_group.main.id}"]
-  key_name                    = "${aws_key_pair.default.key_name}"
-  associate_public_ip_address = true
+
+  root_block_device {
+    delete_on_termination = true
+  }
 
   tags = {
     Name = "tf-acc-panos-${random_id.name.hex}"


### PR DESCRIPTION
By default, the AMIs are set with delete on termination disabled, which leaves a dangling EBS volume where this infrastructure is ran and destroyed.

Verified locally via:

```console
$ cd panos/test-infra/aws-panos
$ terraform init
$ TF_VAR_panos_version=9.0.0 terraform apply
$ TF_VAR_panos_version=9.0.0 terraform destroy
```